### PR TITLE
Make JWT token header key configurable

### DIFF
--- a/src/access.lua
+++ b/src/access.lua
@@ -140,14 +140,22 @@ local function build_payload_hash()
   return str.to_hex(payload_digest)
 end
 
---- Add the JWT header to the reqeust
+local function build_header_value(conf, jwt)
+  if (conf.include_credential_type == true) then
+    return "Bearer " .. jwt
+  else
+    return jwt
+  end
+end
+
+--- Add the JWT header to the request
 -- @param conf the configuration
 local function add_jwt_header(conf)
   local payload_hash = build_payload_hash()
   local payload = build_jwt_payload(conf, payload_hash)
   local kong_private_key = get_kong_key("pkey", get_private_key_location(conf))
   local jwt = encode_jwt_token(conf, payload, kong_private_key)
-  ngx.req.set_header("JWT", jwt)
+  ngx.req.set_header(conf.header, build_header_value(conf, jwt))
 end
 
 --- Execute the script

--- a/src/schema.lua
+++ b/src/schema.lua
@@ -5,6 +5,8 @@ return {
     issuer = { type = "string", required = false },
     private_key_location = { type = "string", required = false },
     public_key_location = { type = "string", required = false },
-    key_id = { type = "string", required = false}
+    key_id = { type = "string", required = false},
+    header = { type = "string", default = "JWT"},
+    include_credential_type = { type = "boolean", default = false}
   }
 }


### PR DESCRIPTION
Adding logic to allow user to set the name of the header key storing the JWT token, as well as a flag to include the credential type (default = `Bearer`) if set.