### PR TITLE
Enhancements to allow configuration of header name and key_id

### DIFF
--- a/src/schema.lua
+++ b/src/schema.lua
@@ -4,6 +4,9 @@ return {
   fields = {
     issuer = { type = "string", required = false },
     private_key_location = { type = "string", required = false },
-    public_key_location = { type = "string", required = false }
+    public_key_location = { type = "string", required = false },
+    key_id = { type = "string", required = false},
+    header = { type = "string", default = "JWT"},
+    include_credential_type = { type = "boolean", default = false}
   }
 }


### PR DESCRIPTION
Enhancements to allow configuration of header name as well as the ability to include the token credential type. Adding option to set the kid claim on the JWT header.

Signed-off-by: Govender, Rowin <rowin.govender@gmail.com>